### PR TITLE
fix: sweep stale awaiting_payment jobs to abandoned in cleanup cron

### DIFF
--- a/tests/Unit/Managers/DatabaseManagerTest.php
+++ b/tests/Unit/Managers/DatabaseManagerTest.php
@@ -267,4 +267,119 @@ class DatabaseManagerTest extends \SMI_TestCase {
     public function jobs_table_constant_is_defined(): void {
         $this->assertEquals( 'smi_jobs', DatabaseManager::JOBS_TABLE );
     }
+
+    /**
+     * @test
+     */
+    public function cleanup_abandoned_jobs_sweeps_stale_awaiting_payment(): void {
+        $stale_job = (object) array( 'job_id' => 'stale-uuid-1' );
+
+        Functions\when( 'get_option' )->justReturn( 24 );
+        Functions\when( 'gmdate' )->justReturn( '2025-01-01 00:00:00' );
+
+        // First query: stale awaiting_payment jobs
+        $this->wpdb_mock
+            ->shouldReceive( 'prepare' )
+            ->andReturnUsing( function () {
+                return 'PREPARED_QUERY';
+            } );
+
+        $this->wpdb_mock
+            ->shouldReceive( 'get_results' )
+            ->twice()
+            ->andReturn( array( $stale_job ), array() );
+
+        // Should update the stale job to abandoned
+        $this->wpdb_mock
+            ->shouldReceive( 'update' )
+            ->once()
+            ->with(
+                'wp_smi_jobs',
+                array( 'status' => 'abandoned' ),
+                array( 'job_id' => 'stale-uuid-1' ),
+                array( '%s' ),
+                array( '%s' )
+            )
+            ->andReturn( 1 );
+
+        // No abandoned jobs to delete
+        $this->wpdb_mock
+            ->shouldReceive( 'delete' )
+            ->never();
+
+        $result = DatabaseManager::cleanup_abandoned_jobs();
+
+        $this->assertEquals( 0, $result );
+    }
+
+    /**
+     * @test
+     */
+    public function cleanup_abandoned_jobs_deletes_old_abandoned_jobs(): void {
+        $abandoned_job = (object) array(
+            'job_id'             => 'abandoned-uuid-1',
+            'upscaled_file_path' => '',
+        );
+
+        Functions\when( 'get_option' )->justReturn( 24 );
+        Functions\when( 'gmdate' )->justReturn( '2025-01-01 00:00:00' );
+
+        $this->wpdb_mock
+            ->shouldReceive( 'prepare' )
+            ->andReturn( 'PREPARED_QUERY' );
+
+        // First call: no stale awaiting_payment; second call: one abandoned job
+        $this->wpdb_mock
+            ->shouldReceive( 'get_results' )
+            ->twice()
+            ->andReturn( array(), array( $abandoned_job ) );
+
+        $this->wpdb_mock
+            ->shouldReceive( 'update' )
+            ->never();
+
+        $this->wpdb_mock
+            ->shouldReceive( 'delete' )
+            ->once()
+            ->with(
+                'wp_smi_jobs',
+                array( 'job_id' => 'abandoned-uuid-1' ),
+                array( '%s' )
+            )
+            ->andReturn( 1 );
+
+        $result = DatabaseManager::cleanup_abandoned_jobs();
+
+        $this->assertEquals( 1, $result );
+    }
+
+    /**
+     * @test
+     */
+    public function cleanup_abandoned_jobs_ignores_recent_awaiting_payment(): void {
+        Functions\when( 'get_option' )->justReturn( 24 );
+        Functions\when( 'gmdate' )->justReturn( '2025-01-01 00:00:00' );
+
+        $this->wpdb_mock
+            ->shouldReceive( 'prepare' )
+            ->andReturn( 'PREPARED_QUERY' );
+
+        // Both queries return empty (recent jobs not included by SQL WHERE)
+        $this->wpdb_mock
+            ->shouldReceive( 'get_results' )
+            ->twice()
+            ->andReturn( array(), array() );
+
+        $this->wpdb_mock
+            ->shouldReceive( 'update' )
+            ->never();
+
+        $this->wpdb_mock
+            ->shouldReceive( 'delete' )
+            ->never();
+
+        $result = DatabaseManager::cleanup_abandoned_jobs();
+
+        $this->assertEquals( 0, $result );
+    }
 }


### PR DESCRIPTION
## Problem

Jobs stuck in `awaiting_payment` status were never transitioning to `abandoned` because the only path was via Stripe's `checkout.session.expired` webhook — which wasn't firing (likely not enabled in Stripe webhook dashboard).

**Evidence:** 13 jobs stuck in `awaiting_payment` since Aug-Sep 2025. Zero jobs have ever had `abandoned` status.

## Fix

`cleanup_abandoned_jobs()` now sweeps stale `awaiting_payment` jobs to `abandoned` status before deleting them. This acts as a safety net regardless of whether the Stripe webhook fires.

### Changes
- **`DatabaseManager::cleanup_abandoned_jobs()`** — Added stale awaiting_payment sweep before existing abandoned deletion logic
- **`DatabaseManagerTest`** — Added 3 tests covering sweep, deletion, and recent-job protection

### Also needed (manual)
- **Stripe Dashboard**: Enable `checkout.session.expired` event in webhook configuration (Developers → Webhooks → select endpoint → add event)

## Testing
Tests added but note: test infrastructure (phpunit.xml, bootstrap.php, composer require-dev) needs setup — tracked separately.