### PR TITLE
fix: abilities return permission error in WP-CLI context

### DIFF
--- a/src/Abilities/AnalyticsAbilities.php
+++ b/src/Abilities/AnalyticsAbilities.php
@@ -290,7 +290,7 @@ class AnalyticsAbilities {
      * Permission callback
      */
     public static function can_manage(): bool {
-        return current_user_can( 'manage_options' );
+        return PermissionHelper::can_manage();
     }
 
     /**

--- a/src/Abilities/InventoryAbilities.php
+++ b/src/Abilities/InventoryAbilities.php
@@ -370,6 +370,6 @@ class InventoryAbilities {
      * Permission check
      */
     public static function can_manage(): bool {
-        return current_user_can( 'manage_options' );
+        return PermissionHelper::can_manage();
     }
 }

--- a/src/Abilities/PermissionHelper.php
+++ b/src/Abilities/PermissionHelper.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Permission helper for Sell My Images abilities.
+ *
+ * Centralizes permission logic to handle WP-CLI and web contexts.
+ *
+ * @package SellMyImages\Abilities
+ * @since 1.7.2
+ */
+
+namespace SellMyImages\Abilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PermissionHelper {
+
+	/**
+	 * Check if current context has admin-level permissions.
+	 *
+	 * Allows execution in:
+	 * - WP-CLI context (command line runs as root/admin)
+	 * - Standard web requests with logged-in admin user
+	 *
+	 * @since 1.7.2
+	 *
+	 * @return bool True if permission granted.
+	 */
+	public static function can_manage(): bool {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return true;
+		}
+
+		return current_user_can( 'manage_options' );
+	}
+}

--- a/src/Abilities/UploadAbilities.php
+++ b/src/Abilities/UploadAbilities.php
@@ -199,7 +199,7 @@ class UploadAbilities {
      * Permission callback - check if user can manage SMI
      */
     public static function can_manage(): bool {
-        return current_user_can( 'manage_options' );
+        return PermissionHelper::can_manage();
     }
 
     /**

--- a/src/Abilities/UpscaleAbilities.php
+++ b/src/Abilities/UpscaleAbilities.php
@@ -95,7 +95,7 @@ class UpscaleAbilities {
      * Permission callback
      */
     public static function can_manage(): bool {
-        return current_user_can( 'manage_options' );
+        return PermissionHelper::can_manage();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Created `PermissionHelper` class that checks for WP-CLI context before falling back to `current_user_can('manage_options')`
- Updated all four ability classes (Analytics, Inventory, Upload, Upscale) to delegate to `PermissionHelper::can_manage()`

## Problem
All SMI abilities with `can_manage` permission callback returned `ability_invalid_permissions` when executed via WP-CLI because `current_user_can('manage_options')` fails without a logged-in user context.

## Fix
Follows the same pattern as Data Machine's `PermissionHelper` — WP-CLI runs as root/admin, so permission checks should pass automatically in that context.

## Testing
Verified all analytics abilities now work from CLI:
- `smi/get-sales-summary` ✅
- `smi/get-conversion-funnel` ✅  
- `smi/get-top-selling-posts` ✅